### PR TITLE
Eigenpro for kernels with K(x,x) != 1

### DIFF
--- a/eigenpro.py
+++ b/eigenpro.py
@@ -73,8 +73,7 @@ def asm_eigenpro_fn(samples, map_fn, top_q, bs_gpu, alpha, min_q=5, seed=1):
     print("SVD time: %.2f, top_q: %d, top_eigval: %.2f, new top_eigval: %.2e" %
           (time.time() - start, top_q, eigvals[0], eigvals[0] / scale))
 
-    knorms = 1 - np.sum(eigvecs ** 2, axis=1) * n_sample
-    beta = np.max(knorms)
+    beta = kmat.diag().max()
 
     return eigenpro_fn, scale, eigvals[0], utils.float_x(beta)
 


### PR DESCRIPTION
Currently beta is set to `1 - knorms` based on the equation following equation (7) from [this paper](https://mlsys.org/Conferences/2019/doc/2019/171.pdf) This implicitly assumes K(x,x) = 1 for all x.
This behavior is unsafe, especially when using Neural Tangent Kernel where K(x,x) scales with depth.

The update explicitly calculates beta as per its definition `max_i K(x_i, x_i)` in [this paper](https://arxiv.org/pdf/1712.06559.pdf) which is the basis for other rules for automatic tuning of hyperparameters.